### PR TITLE
Update Dockerfile base image and OpenSSH version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM alpine:3.19
+FROM alpine:3.23
 
 ENV SOCKET_DIR=/tmp/amazeeio_ssh-agent
 ENV SSH_AUTH_SOCK=${SOCKET_DIR}/socket
-RUN apk add --update \
-      openssh=~9.6_p1 \
+
+RUN apk add --update --no-cache \
+      openssh=~10.2 \
       sudo \
     && rm -rf /var/cache/apk/*
 RUN adduser -D -u 1000 drupal


### PR DESCRIPTION
This pull request updates the base image and SSH package version in the `Dockerfile` to improve security and compatibility. The most important changes are:

**Base Image and Dependency Updates:**

* Updated the base image from `alpine:3.19` to `alpine:3.23` for improved security and newer package availability.
* Upgraded `openssh` from version `~9.6_p1` to `~10.2` to address potential vulnerabilities and ensure compatibility with newer SSH features.
* Added the `--no-cache` flag to the `apk add` command to reduce image size and prevent caching of package index files.

**General Maintenance:**

* Minor reformatting of the `RUN` command for clarity and best practices.